### PR TITLE
feat: Optimize performance with background polling and add project filtering via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Flags:
                             Comma-separated list of project tags to filter on
       --dtrack.poll-interval=6h
                             Interval to poll Dependency-Track for metrics
+      --dtrack.initialize-violation-metrics
+                            Initialize all possible violation metric combinations to 0 (default: true)
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt   Output format of log messages. One of: [logfmt, json]
       --version             Show application version.
@@ -35,14 +37,32 @@ The API key the exporter uses needs to have the following permissions:
 
 | Metric                                          | Meaning                                                               | Labels                                           |
 | ----------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
-| dependency_track_portfolio_inherited_risk_score | The inherited risk score of the whole portfolio.                      |                                                  |
-| dependency_track_portfolio_vulnerabilities      | Number of vulnerabilities across the whole portfolio, by severity.    | severity                                         |
-| dependency_track_portfolio_findings             | Number of findings across the whole portfolio, audited and unaudited. | audited                                          |
-| dependency_track_project_info                   | Project information.                                                  | uuid, name, version, active, tags                |
-| dependency_track_project_vulnerabilities        | Number of vulnerabilities for a project by severity.                  | uuid, name, version, severity                    |
-| dependency_track_project_policy_violations      | Policy violations for a project.                                      | uuid, name, version, state, analysis, suppressed |
-| dependency_track_project_last_bom_import        | Last BOM import date, represented as a Unix timestamp.                | uuid, name, version                              |
-| dependency_track_project_inherited_risk_score   | Inherited risk score for a project.                                   | uuid, name, version                              |
+| dependency_track_portfolio_inherited_risk_score | The inherited risk score of the whole portfolio.                      |                                                        |
+| dependency_track_portfolio_vulnerabilities      | Number of vulnerabilities across the whole portfolio, by severity.    | severity                                               |
+| dependency_track_portfolio_findings             | Number of findings across the whole portfolio, audited and unaudited. | audited                                                |
+| dependency_track_project_info                   | Project information.                                                  | uuid, name, version, classifier, active, tags          |
+| dependency_track_project_vulnerabilities        | Number of vulnerabilities for a project by severity.                  | uuid, name, version, severity                          |
+| dependency_track_project_policy_violations      | Policy violations for a project.                                      | uuid, name, version, type, state, analysis, suppressed |
+| dependency_track_project_last_bom_import        | Last BOM import date, represented as a Unix timestamp.                | uuid, name, version                                    |
+| dependency_track_project_inherited_risk_score   | Inherited risk score for a project.                                   | uuid, name, version                                    |
+
+## Performance & Memory Optimization
+
+If you have a very large Dependency-Track portfolio, the exporter can consume significant memory during polling due to the high cardinality of policy violation metrics.
+
+### High-Cardinality Metrics
+By default, the exporter initializes 72 unique metric series for every project (combinations of violation types, states, etc.) to ensure they record `0` instead of being absent. 
+
+To significantly reduce memory usage, you can disable this behavior:
+
+```bash
+--dtrack.initialize-violation-metrics=false
+```
+
+When disabled, metric series will only be created when an actual violation is detected.
+
+### Streaming
+The exporter uses streaming pagination to fetch data from Dependency-Track, ensuring that memory usage remains stable even as your portfolio grows.
 
 ## Example queries
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Flags:
                             Address to listen on for web interface and telemetry.
       --web.metrics-path="/metrics"
                             Path under which to expose metrics
-      --dtrack.address="http://localhost:8080"
-                            Dependency-Track server address (can also be set with $DEPENDENCY_TRACK_ADDR)
+      --dtrack.address=DTRACK.ADDRESS
+                            Dependency-Track server address (default: http://localhost:8080 or $DEPENDENCY_TRACK_ADDR)
       --dtrack.api-key=DTRACK.API-KEY
-                            Dependency-Track API key (can also be set with $DEPENDENCY_TRACK_API_KEY)
+                            Dependency-Track API key (default: $DEPENDENCY_TRACK_API_KEY)
       --dtrack.project-tags=DTRACK.PROJECT-TAGS
                             Comma-separated list of project tags to filter on
       --dtrack.poll-interval=6h

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Flags:
                             Dependency-Track API key (can also be set with $DEPENDENCY_TRACK_API_KEY)
       --dtrack.project-tags=DTRACK.PROJECT-TAGS
                             Comma-separated list of project tags to filter on
-      --dtrack.project-version-regex=DTRACK.PROJECT-VERSION-REGEX
-                            Regex to filter project versions
       --dtrack.poll-interval=6h
                             Interval to poll Dependency-Track for metrics
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ Flags:
                             Address to listen on for web interface and telemetry.
       --web.metrics-path="/metrics"
                             Path under which to expose metrics
-      --dtrack.address=DTRACK.ADDRESS
-                            Dependency-Track server address (default: http://localhost:8080 or $DEPENDENCY_TRACK_ADDR)
+      --dtrack.address="http://localhost:8080"
+                            Dependency-Track server address (can also be set with $DEPENDENCY_TRACK_ADDR)
       --dtrack.api-key=DTRACK.API-KEY
-                            Dependency-Track API key (default: $DEPENDENCY_TRACK_API_KEY)
+                            Dependency-Track API key (can also be set with $DEPENDENCY_TRACK_API_KEY)
+      --dtrack.project-tags=DTRACK.PROJECT-TAGS
+                            Comma-separated list of project tags to filter on
+      --dtrack.project-version-regex=DTRACK.PROJECT-VERSION-REGEX
+                            Regex to filter project versions
+      --dtrack.poll-interval=6h
+                            Interval to poll Dependency-Track for metrics
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt   Output format of log messages. One of: [logfmt, json]
       --version             Show application version.

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -283,10 +283,10 @@ func (e *Exporter) collectProjectMetrics(ctx context.Context, registry *promethe
 		if e.InitializeViolationMetrics {
 			for _, possibleType := range []string{"LICENSE", "OPERATIONAL", "SECURITY"} {
 				for _, possibleState := range []string{"INFO", "WARN", "FAIL"} {
-					for _, possibleAnalysis := range []string{
-						string(dtrack.ViolationAnalysisStateApproved),
-						string(dtrack.ViolationAnalysisStateRejected),
-						string(dtrack.ViolationAnalysisStateNotSet),
+					for _, possibleAnalysis := range []dtrack.ViolationAnalysisState{
+						dtrack.ViolationAnalysisStateApproved,
+						dtrack.ViolationAnalysisStateRejected,
+						dtrack.ViolationAnalysisStateNotSet,
 						"",
 					} {
 						for _, possibleSuppressed := range []string{"true", "false"} {
@@ -296,7 +296,7 @@ func (e *Exporter) collectProjectMetrics(ctx context.Context, registry *promethe
 								project.Version,
 								possibleType,
 								possibleState,
-								possibleAnalysis,
+								string(possibleAnalysis),
 								possibleSuppressed,
 							).Set(0)
 						}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -236,11 +236,9 @@ func (e *Exporter) collectProjectMetrics(ctx context.Context, registry *promethe
 		projectUUID := project.UUID.String()
 		matchedProjects[projectUUID] = struct{}{}
 
-		var projTags strings.Builder
-		projTags.WriteByte(',')
+		var tags []string
 		for _, t := range project.Tags {
-			projTags.WriteString(t.Name)
-			projTags.WriteByte(',')
+			tags = append(tags, t.Name)
 		}
 
 		info.WithLabelValues(
@@ -249,7 +247,7 @@ func (e *Exporter) collectProjectMetrics(ctx context.Context, registry *promethe
 			project.Version,
 			project.Classifier,
 			strconv.FormatBool(project.Active),
-			projTags.String(),
+			strings.Join(tags, ","),
 		).Set(1)
 
 		severities := map[string]int{

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -3,7 +3,6 @@ package exporter
 import (
 	"context"
 	"net/http"
-	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -23,10 +22,9 @@ const (
 
 // Exporter exports metrics from a Dependency-Track server
 type Exporter struct {
-	Client         *dtrack.Client
-	Logger         log.Logger
-	ProjectTags    []string
-	ProjectVersion *regexp.Regexp
+	Client      *dtrack.Client
+	Logger      log.Logger
+	ProjectTags []string
 
 	mutex    sync.RWMutex
 	registry *prometheus.Registry
@@ -371,13 +369,6 @@ func (e *Exporter) projectMatches(project dtrack.Project) bool {
 			}
 		}
 		if !found {
-			return false
-		}
-	}
-
-	// Filter by version
-	if e.ProjectVersion != nil {
-		if !e.ProjectVersion.MatchString(project.Version) {
 			return false
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"regexp"
 	"strings"
 	"syscall"
 
@@ -33,14 +32,13 @@ func init() {
 
 func main() {
 	var (
-		webConfig        = webflag.AddFlags(kingpin.CommandLine, ":9916")
-		metricsPath      = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
-		dtAddress        = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
-		dtAPIKey         = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
-		dtProjectTags    = kingpin.Flag("dtrack.project-tags", "Comma-separated list of project tags to filter on").String()
-		dtProjectVersion = kingpin.Flag("dtrack.project-version-regex", "Regex to filter project versions").String()
-		pollInterval     = kingpin.Flag("dtrack.poll-interval", "Interval to poll Dependency-Track for metrics").Default("6h").Duration()
-		promlogConfig    = promlog.Config{}
+		webConfig     = webflag.AddFlags(kingpin.CommandLine, ":9916")
+		metricsPath   = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
+		dtAddress     = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
+		dtAPIKey      = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
+		dtProjectTags = kingpin.Flag("dtrack.project-tags", "Comma-separated list of project tags to filter on").String()
+		pollInterval  = kingpin.Flag("dtrack.poll-interval", "Interval to poll Dependency-Track for metrics").Default("6h").Duration()
+		promlogConfig = promlog.Config{}
 	)
 
 	flag.AddFlags(kingpin.CommandLine, &promlogConfig)
@@ -59,25 +57,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	var projectVersion *regexp.Regexp
-	if *dtProjectVersion != "" {
-		projectVersion, err = regexp.Compile(*dtProjectVersion)
-		if err != nil {
-			level.Error(logger).Log("msg", "Error compiling project version regex", "err", err)
-			os.Exit(1)
-		}
-	}
-
 	var projectTags []string
 	if *dtProjectTags != "" {
 		projectTags = strings.Split(*dtProjectTags, ",")
 	}
 
 	e := exporter.Exporter{
-		Client:         c,
-		Logger:         logger,
-		ProjectTags:    projectTags,
-		ProjectVersion: projectVersion,
+		Client:      c,
+		Logger:      logger,
+		ProjectTags: projectTags,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/main.go
+++ b/main.go
@@ -32,13 +32,14 @@ func init() {
 
 func main() {
 	var (
-		webConfig     = webflag.AddFlags(kingpin.CommandLine, ":9916")
-		metricsPath   = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
-		dtAddress     = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
-		dtAPIKey      = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
-		dtProjectTags = kingpin.Flag("dtrack.project-tags", "Comma-separated list of project tags to filter on").String()
-		pollInterval  = kingpin.Flag("dtrack.poll-interval", "Interval to poll Dependency-Track for metrics").Default("6h").Duration()
-		promlogConfig = promlog.Config{}
+		webConfig                    = webflag.AddFlags(kingpin.CommandLine, ":9916")
+		metricsPath                  = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
+		dtAddress                    = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
+		dtAPIKey                     = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
+		dtProjectTags                = kingpin.Flag("dtrack.project-tags", "Comma-separated list of project tags to filter on").String()
+		pollInterval                 = kingpin.Flag("dtrack.poll-interval", "Interval to poll Dependency-Track for metrics").Default("6h").Duration()
+		dtInitializeViolationMetrics = kingpin.Flag("dtrack.initialize-violation-metrics", "Initialize all possible violation metric combinations to 0 (can also be set with $DEPENDENCY_TRACK_INITIALIZE_VIOLATION_METRICS)").Default("true").Envar("DEPENDENCY_TRACK_INITIALIZE_VIOLATION_METRICS").Bool()
+		promlogConfig                = promlog.Config{}
 	)
 
 	flag.AddFlags(kingpin.CommandLine, &promlogConfig)
@@ -63,9 +64,10 @@ func main() {
 	}
 
 	e := exporter.Exporter{
-		Client:      c,
-		Logger:      logger,
-		ProjectTags: projectTags,
+		Client:                     c,
+		Logger:                     logger,
+		ProjectTags:                projectTags,
+		InitializeViolationMetrics: *dtInitializeViolationMetrics,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
- Implemented background polling: Added an internal cache and background worker to refresh metrics asynchronously, preventing scrape timeouts and reducing load on the Dependency-Track API.
- Added tag-based project filtering: New --dtrack.project-tags flag to export metrics only for projects matching specific tags.
- Refactored metrics collection to use a push-based registry model, significantly improving performance in environments with many projects.